### PR TITLE
Add Python 3 and Thumbor 7 support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,5 +7,5 @@ test:
   override:
     - make pyvows_run
   post:
-    - fpm -s python -t deb --iteration 1 --no-python-dependencies -d python-dateutil -d thumbor -d python-boto --python-install-lib /usr/lib/python2.7/dist-packages -x "*.pyc" ./setup.py
+    - fpm -s python -t deb --iteration 1 --no-python-dependencies -d python-dateutil -d thumbor -d python-boto --python-install-lib /usr/lib/python3.8/dist-packages -x "*.pyc" ./setup.py
     - mv ./*.deb $CIRCLE_ARTIFACTS

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,8 +50,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Thumbor Community Core'
-copyright = u'Thumbor Community'
+project = 'Thumbor Community Core'
+copyright = 'Thumbor Community'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -248,8 +248,8 @@ latex_elements = {
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'Thumbor Community', u'Thumbor Community Documentation',
-   u'@masom', 'Thumbor Community', 'Thumbor Community Extensions',
+  ('index', 'Thumbor Community', 'Thumbor Community Documentation',
+   '@masom', 'Thumbor Community', 'Thumbor Community Extensions',
    'Miscellaneous'),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,22 @@
 # -*- coding: utf-8 -*-
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 setup(
     name='tc_core',
-    version='0.4.1',
+    version='0.5',
     url='http://github.com/thumbor_community/core',
     license='MIT',
     author='Thumbor Community',
     description='Thumbor community extensions core',
-    packages=['tc_core'],
+    packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'libthumbor>=1.3.0',
-        'thumbor>=5.0',
+        'libthumbor>=2.0.2',
+        'thumbor>=7.0.10',
     ],
     extras_require={
         'tests': [
@@ -29,7 +29,11 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]
 )

--- a/tc_core/__init__.py
+++ b/tc_core/__init__.py
@@ -11,7 +11,7 @@ from tc_core.context_importer import ContextImporter
 from tc_core.importer import Importer
 
 
-class Extensions(object):
+class Extensions:
 
     extensions = []
 
@@ -39,7 +39,7 @@ class Extensions(object):
         Importer.register_module(config_key, class_name, multiple)
 
 
-class Extension(object):
+class Extension:
 
     def __init__(self, name):
         '''

--- a/tc_core/app.py
+++ b/tc_core/app.py
@@ -4,9 +4,6 @@
 # Use of this source code is governed by the MIT license that can be
 # found in the LICENSE file.
 
-import tornado.web
-import tornado.ioloop
-
 from thumbor.app import ThumborServiceApp
 from thumbor.handlers import ContextHandler
 from thumbor.utils import logger
@@ -46,7 +43,7 @@ class App(ThumborServiceApp):
 
             ContextHandler.initialize = initialize
 
-        super(App, self).__init__(context)
+        super().__init__(context)
 
     def get_handlers(self):
         '''Return a list of tornado web handlers.
@@ -67,6 +64,6 @@ class App(ThumborServiceApp):
 
                 handlers.append(handler)
 
-        handlers.extend(super(App, self).get_handlers())
+        handlers.extend(super().get_handlers())
 
         return handlers

--- a/tc_core/importer.py
+++ b/tc_core/importer.py
@@ -8,7 +8,7 @@ from thumbor.utils import logger
 from thumbor.importer import Importer as ThumborImporter
 
 
-class Importer(object):
+class Importer:
 
     _community_modules = []
 

--- a/tc_core/web.py
+++ b/tc_core/web.py
@@ -13,7 +13,7 @@ if hasattr(tornado.web, '_unquote_or_none'):
 else:
     from tornado.routing import _unquote_or_none
 
-class RequestParser(object):
+class RequestParser:
 
     _url_regex = None
 
@@ -36,15 +36,16 @@ class RequestParser(object):
             # unnamed groups, we want to use either groups
             # or groupdict but not both.
             if cls._url_regex.groupindex:
-                parameters = dict(
+                parameters = {
                     (str(k), _unquote_or_none(v))
-                    for (k, v) in match.groupdict().items())
+                    for (k, v) in match.groupdict().items()
+                    }
             else:
                 parameters = [
                     _unquote_or_none(s)
                     for s in match.groups()
                 ]
         else:
-            parameters = dict()
+            parameters = {}
 
         return parameters

--- a/vows/context_importer_vows.py
+++ b/vows/context_importer_vows.py
@@ -18,6 +18,10 @@ class Importer(object):
     detectors = []
     filters = []
     optimizers = []
+    compatibility_legacy_loader = None
+    compatibility_legacy_storage = None
+    compatibility_legacy_result_storage = None
+
 
 class Extension(object):
 


### PR DESCRIPTION
Minor updates to bring the module up to Python 3 standard.

* Use find_packages to protect against deprecation of automatic inclusion of importable packages
* Add required parameters for Importer object to vows

vows run successfully using updated Thumbor libraries and Python 3.9. Addresses #21. 